### PR TITLE
Receptionist has to be a class (not a trait)

### DIFF
--- a/src/main/scala/com/xebia/exercise3/Receptionist.scala
+++ b/src/main/scala/com/xebia/exercise3/Receptionist.scala
@@ -12,7 +12,7 @@ import spray.routing._
 import spray.httpx.SprayJsonSupport._
 import spray.http.StatusCodes
 
-trait Receptionist extends HttpServiceActor
+class Receptionist extends HttpServiceActor
                       with ReverseRoute
                       with ActorContextCreationSupport {
   implicit def executionContext = context.dispatcher


### PR DESCRIPTION
As a trait, there is no default constructor, so the actor cannot be instantiated. 'sbt run' generates: java.lang.IllegalArgumentException: no matching constructor found on interface com.xebia.exercise4.Receptionist for arguments []
